### PR TITLE
fix: AWS OIDC authentication for staging CI ECR push

### DIFF
--- a/.github/workflows/staging-production-ci.yml
+++ b/.github/workflows/staging-production-ci.yml
@@ -171,7 +171,7 @@ jobs:
       if: github.ref == 'refs/heads/staging'
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::762233763891:role/GitHubActionsRole
+        role-to-assume: arn:aws:iam::762233763891:role/GitHubActions-SoundBite-Prod
         aws-region: ${{ env.AWS_REGION }}
         
     - name: Login to Amazon ECR

--- a/trust-policy.json
+++ b/trust-policy.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "GitHubOIDCTrust",
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::762233763891:oidc-provider/token.actions.githubusercontent.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                    "token.actions.githubusercontent.com:sub": [
+                        "repo:SinaVosooghi/SoundBite:ref:refs/heads/staging",
+                        "repo:SinaVosooghi/SoundBite:ref:refs/heads/master",
+                        "repo:SinaVosooghi/SoundBite:ref:refs/tags/v*"
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## 🔧 AWS OIDC Authentication Fix

### Problem:
Staging CI was failing with OIDC error: 'Not authorized to perform sts:AssumeRoleWithWebIdentity'

### Root Cause:
1. Wrong role name:  → 
2. Trust policy only allowed tags () but not staging branch ()

### Fix Applied:
- ✅ Updated role name to correct 
- ✅ Updated trust policy to allow staging and master branches
- ✅ ECR push should now work on staging branch pushes

### Test:
This PR will test the ECR push functionality on staging branch.